### PR TITLE
[#13] Lunch 데이터 그리드 보기 좋게 하기

### DIFF
--- a/lt-webapp/package.json
+++ b/lt-webapp/package.json
@@ -52,6 +52,7 @@
     "vue-template-compiler": "^2.6.11"
   },
   "prettier": {
+    "arrowParens": "avoid",
     "tabWidth": 4,
     "printWidth": 80,
     "vueIndentScriptAndStyle": true

--- a/lt-webapp/src/App.vue
+++ b/lt-webapp/src/App.vue
@@ -22,12 +22,12 @@
         font-family: Avenir, Helvetica, Arial, sans-serif;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
-        text-align: center;
         color: #2c3e50;
     }
 
     #nav {
         padding: 30px;
+        text-align: center;
 
         a {
             font-weight: bold;

--- a/lt-webapp/src/common/DataLoader.ts
+++ b/lt-webapp/src/common/DataLoader.ts
@@ -1,4 +1,5 @@
 import datasource from "@/data/datasource.json";
+import * as FormatUtil from "@/common/FormatUtil";
 import { Lunch, Place } from "@/common/TypeDef";
 
 const NullString = "";
@@ -9,26 +10,6 @@ function getValueWithDefault(value: any, defaultValue: any): any {
     if (value === null || value === undefined || value === NullString)
         return defaultValue;
     return value;
-}
-
-function substringAsNumber(str: string, start: number, end: number): number {
-    return Number(str.substring(start, end));
-}
-
-// TODO Type을 define하는 방법도 있는지 찾아보자.
-function getDateFromDateOnlyStr(dateOnlyStr: string): Date {
-    // prettier-ignore
-    if (dateOnlyStr.length !== 8)
-        return new Date(-1);
-
-    return new Date(
-        substringAsNumber(dateOnlyStr, 0, 4),
-        substringAsNumber(dateOnlyStr, 4, 6),
-        substringAsNumber(dateOnlyStr, 6, 8),
-        0,
-        0,
-        0
-    );
 }
 // 여기까지 위치가 애매하다. 일단은 여기서 쓰니까 여기 둔다.
 
@@ -42,7 +23,7 @@ export const lunch: Array<Lunch> = datasource.lunch.map(l => ({
     id: l.no,
     menu: l.name,
     price: getValueWithDefault(l.price, 0),
-    date: new Date(getDateFromDateOnlyStr(l.date)),
+    date: new Date(FormatUtil.getDateFromDateOnlyStr(l.date)),
     placeId: l.placeNo
 }));
 Object.freeze(lunch);

--- a/lt-webapp/src/common/FormatUtil.ts
+++ b/lt-webapp/src/common/FormatUtil.ts
@@ -1,0 +1,31 @@
+function numberPadStartWithZero(number: number, length: number): string {
+    return number.toString().padStart(length, "0");
+}
+
+function substringAsNumber(str: string, start: number, end: number): number {
+    return Number(str.substring(start, end));
+}
+
+export function dateToDateOnlyStr(date: Date): string {
+    return [
+        numberPadStartWithZero(date.getFullYear(), 4),
+        numberPadStartWithZero(date.getMonth() + 1, 2),
+        numberPadStartWithZero(date.getDate(), 2)
+    ].join("-");
+}
+
+// TODO Type을 define하는 방법도 있는지 찾아보자.
+export function getDateFromDateOnlyStr(dateOnlyStr: string): Date {
+    // prettier-ignore
+    if (dateOnlyStr.length !== 8)
+        return new Date(-1);
+
+    return new Date(
+        substringAsNumber(dateOnlyStr, 0, 4),
+        substringAsNumber(dateOnlyStr, 4, 6),
+        substringAsNumber(dateOnlyStr, 6, 8),
+        0,
+        0,
+        0
+    );
+}

--- a/lt-webapp/src/components/LunchTrackingPane.vue
+++ b/lt-webapp/src/components/LunchTrackingPane.vue
@@ -11,6 +11,7 @@
 <script lang="ts">
     import AgGridVue from "@/common/AgGridVue.ts";
     import Vue from "vue";
+    import * as FormatUtil from "@/common/FormatUtil.ts";
     import * as DataLoader from "@/common/DataLoader.ts";
     import { NumberKeyObject, Place } from "@/common/TypeDef";
     import {
@@ -21,13 +22,23 @@
     } from "@ag-grid-community/all-modules";
 
     const columnDefs: Array<ColDef> = [
-        { headerName: "일시", field: "date" },
+        {
+            headerName: "일시",
+            field: "date",
+            valueFormatter: param => FormatUtil.dateToDateOnlyStr(param.value)
+        },
         { headerName: "메뉴", field: "name" },
-        { headerName: "가격", field: "price" },
+        {
+            headerName: "가격",
+            field: "price",
+            cellStyle: { "text-align": "right" },
+            valueFormatter: param =>
+                param.value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")
+        },
         { headerName: "식당", field: "place" }
     ];
     // prettier-ignore
-    const placeMapById: NumberKeyObject = 
+    const placeMapById: NumberKeyObject =
         DataLoader.place.reduce((res: NumberKeyObject, p: Place) => {
             res[p.id] = p;
             return res;


### PR DESCRIPTION
* 기존 DateLoader에 선언되어있던 getDateFromDateOnlyStr()을 FormatUtil.ts 파일로 이동
* prettier 설정 추가 ("arrowParens": "avoid")

** cellStyle 대신 type: 'rightAligned', type: 'numericColumn'도 사용할 수 있는데 헤더까지 정렬한다.